### PR TITLE
Tag Improvements, Endorse Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -81,7 +81,21 @@ public class EditCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
-        Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
+        Set<SkillsTag> previousTags = new HashSet<>(personToEdit.getTags());
+        Set<SkillsTag> endorsements = new HashSet<>();
+
+        for(SkillsTag s: previousTags){
+            if(s.tagType.equals("endorse")){
+                endorsements.add(s);
+            }
+        }
+
+        Person changedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
+        Set<SkillsTag> editedTags = new HashSet<>(changedPerson.getTags());
+        editedTags.addAll(endorsements);
+        Person editedPerson = new Person(changedPerson.getName(), changedPerson.getPhone(), changedPerson.getEmail(),
+                changedPerson.getEducation(), changedPerson.getGpa(), changedPerson.getAddress(), editedTags);
+
 
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);

--- a/src/main/java/seedu/address/logic/commands/EndorseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EndorseCommand.java
@@ -1,0 +1,71 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.SkillsTag;
+
+/**
+ * Endorses a person in the recruiter platform.
+ */
+public class EndorseCommand extends Command{
+    public static final String COMMAND_WORD = "endorse";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": " +
+            "Endorses a candidate in the recruiting list. "
+            + "Parameters: " +
+            " endorse " + "(index) " + "n/(your name) "+
+            "EXAMPLE: endorse 2 n/Warren Buffett";
+
+    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Endorsed Person: %1$s";
+    public static final String MESSAGE_DUPLICATE_PERSON = "You have already endorsed this person";
+
+    private final Index index;
+    private final String endorseName;
+
+    /**
+     * @param index of the person in the filtered person list to edit
+     */
+    public EndorseCommand(Index index, String endorseName) {
+        requireNonNull(index);
+        this.index = index;
+        this.endorseName = endorseName;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getAddressBook().getPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToEdit = lastShownList.get(index.getZeroBased());
+
+        Set<SkillsTag> personTags = new HashSet<>(personToEdit.getTags());
+        if(personToEdit.isTagExist(endorseName)){
+            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+        personTags.add(new SkillsTag(endorseName, "endorse"));
+
+        Person editedPerson = new Person(personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
+                personToEdit.getEducation(), personToEdit.getGpa(), personToEdit.getAddress(), personTags);
+
+
+        model.setPerson(personToEdit, editedPerson);
+        model.commitAddressBook();
+        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson.getName()));
+    }
+
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -11,6 +11,7 @@ import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EndorseCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -91,6 +92,9 @@ public class AddressBookParser {
 
         case FilterCommand.COMMAND_WORD:
             return new FilterCommandParser().parse(arguments);
+
+        case EndorseCommand.COMMAND_WORD:
+            return new EndorseCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -74,7 +74,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_SKILL), "skill").ifPresent(editPersonDescriptor::setTags);
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_POS), "position").ifPresent(editPersonDescriptor::setTags);
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_POS), "pos").ifPresent(editPersonDescriptor::setTags);
 
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {

--- a/src/main/java/seedu/address/logic/parser/EndorseCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EndorseCommandParser.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EndorseCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class EndorseCommandParser implements Parser<EndorseCommand>{
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the SelectCommand
+     * and returns an SelectCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+
+    public EndorseCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME);
+
+        String endorseName = null;
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, EndorseCommand.MESSAGE_USAGE), pe);
+        }
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            endorseName = argMultimap.getValue(PREFIX_NAME).get();
+        }
+
+        return new EndorseCommand(index, endorseName);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -104,13 +104,13 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code tag} is invalid.
      */
-    public static SkillsTag parseTag(String tag, String color) throws ParseException {
+    public static SkillsTag parseTag(String tag, String type) throws ParseException {
         requireNonNull(tag);
         String trimmedTag = tag.trim();
         if (!SkillsTag.isValidTagName(trimmedTag)) {
             throw new ParseException(SkillsTag.MESSAGE_CONSTRAINTS);
         }
-        return new SkillsTag(trimmedTag, color);
+        return new SkillsTag(trimmedTag, type);
     }
 
     /**
@@ -149,14 +149,9 @@ public class ParserUtil {
     public static Set<SkillsTag> parseTags(Collection<String> tags, String type) throws ParseException {
         requireNonNull(tags);
         final Set<SkillsTag> tagSet = new HashSet<>();
-        final String color;
-        if (type.equals("skill")) {
-            color = "yellow";
-        } else {
-            color = "pink";
-        }
+        //final String color;
         for (String tagName : tags) {
-            tagSet.add(parseTag(tagName, color));
+            tagSet.add(parseTag(tagName, type));
         }
         return tagSet;
     }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -82,9 +82,8 @@ public class Person {
      * Checks if a tag as a String parameter is contained in one of the tags of that person
      */
     public boolean isTagExist(String tag) {
-
         for (SkillsTag skill : tags) {
-            if (skill.tagName.toLowerCase().contains(tag)) {
+            if (skill.tagName.toLowerCase().contains(tag) || skill.tagName.contains(tag)) {
                 return true;
             }
         }

--- a/src/main/java/seedu/address/model/tag/SkillsTag.java
+++ b/src/main/java/seedu/address/model/tag/SkillsTag.java
@@ -10,28 +10,43 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class SkillsTag {
 
     public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String VALIDATION_REGEX = "[\\p{ASCII}][\\p{ASCII} ]*";
 
     public final String tagName;
     public final String tagColor;
+    public final String tagType;
 
     /**
      * Constructs a {@code SkillsTag}.
      *
      * @param tagName A valid tag name.
+     * @param type
      */
-    public SkillsTag(String tagName, String color) {
+    public SkillsTag(String tagName, String type) {
         requireNonNull(tagName);
         checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
         this.tagName = tagName;
-        this.tagColor = color;
+        this.tagType = type;
+        if(type.equals("skill")){
+            //skill tag
+            this.tagColor = "yellow";
+
+        }else if(type.equals("pos")){
+            //position tag
+            this.tagColor = "pink";
+
+        }else{
+            //endorsement tag
+            this.tagColor = "teal";
+        }
     }
 
     public SkillsTag(String tagName) {
         requireNonNull(tagName);
         checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
         this.tagName = tagName;
-        this.tagColor = "yellow";
+        this.tagColor = null;
+        this.tagType = null;
     }
 
     /**

--- a/src/main/java/seedu/address/model/tag/SkillsTag.java
+++ b/src/main/java/seedu/address/model/tag/SkillsTag.java
@@ -29,11 +29,11 @@ public class SkillsTag {
         this.tagType = type;
         if(type.equals("skill")){
             //skill tag
-            this.tagColor = "yellow";
+            this.tagColor = "pink";
 
         }else if(type.equals("pos")){
             //position tag
-            this.tagColor = "pink";
+            this.tagColor = "yellow";
 
         }else{
             //endorsement tag

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -24,24 +24,71 @@ public class SampleDataUtil {
         return new Person[]{
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                     new Education("NUS"), new Gpa("3"), new Address("Blk 30 Geylang Street 29, #06-40"),
-                    getTagSet(Arrays.asList("PHP", "Java"), Arrays.asList("UI Developer",
-                            "Advanced Graphics Designer"))),
+                    getTagSet(Arrays.asList("PHP", "Java", "Debugging", "C#", "Internet Protocols"), Arrays.asList(
+                            "UI Developer",
+                            "Advanced Graphics Designer"), Arrays.asList("Steve Jobs", "Mark Cuban"))),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                     new Education("NUS"), new Gpa("3"), new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                    getTagSet(Arrays.asList("HTML", "JavaScript", "C++"), Arrays.asList("Front End Specialist",
-                            "Web Developer"))),
+                    getTagSet(Arrays.asList("HTML", "JavaScript", "C++", "Perl", "Linux", "Task Management"),
+                            Arrays.asList("Front End Specialist",
+                            "Software Engineer"), Arrays.asList("Mark Zuckerberg"))),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                     new Education("NUS"), new Gpa("3"), new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                    getTagSet(Arrays.asList("C++", "Java"), Arrays.asList("Cyber Crime Analyst"))),
+                    getTagSet(Arrays.asList("C++", "Java", "Swift", "Certificates", "Networking"), Arrays.asList(
+                            "Cyber Crime "),
+                            Arrays.asList("Barack Obama"))),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                     new Education("NUS"), new Gpa("3"), new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                    getTagSet(Arrays.asList("Python", "SQL"), Arrays.asList("Databases", "Systems Analyst"))),
+                    getTagSet(Arrays.asList("Python", "SQL", "Database Administration", "Project Management",
+                            "Software Testing"),
+                            Arrays.asList(
+                            "Databases",
+                            "Systems " +
+                                    "Analyst"),
+                            Arrays.asList("Bill Gates", "Frederick Brooks"))),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                     new Education("NUS"), new Gpa("3"), new Address("Blk 47 Tampines Street 20, #17-35"),
-                    getTagSet(Arrays.asList("Java", "JavaScript"), Arrays.asList("Software Engineer"))),
+                    getTagSet(Arrays.asList("Java", "JavaScript", "Excel", "Hadoop", "Market Analysis"), Arrays.asList(
+                            "Software " +
+                                    "Engineer",
+                            "Financial Analyst"),
+                            Arrays.asList(
+                            "Jeff Bezos", "Warren Buffett"))),
+                new Person(new Name("Susan McDonald"), new Phone("35810495"), new Email("susanM@gmail.com"),
+                        new Education("Yale"), new Gpa("4"), new Address("32 Independence Way, New York NY"),
+                        getTagSet(Arrays.asList("Java", "HTML", "CSS", "JavaScript", "Swift"), Arrays.asList("Front " +
+                                "End Specialist", "UI Developer", "Project Manager"), Arrays.asList("Jeff Bezos"))),
+            new Person(new Name("Tony Stark"), new Phone("92874639"), new Email("tonys@avengers.com"),
+                    new Education("MIT"), new Gpa("4"), new Address("911 Avengers Way, New York NY"),
+                    getTagSet(Arrays.asList("Java", "Electrical Engineering", "MATLab", "Software Development",
+                            "Leadership", "Presentation Skills"), Arrays.asList("Software Engineer", "Project Manager"),
+                            Arrays.asList(
+                                "Stan Lee"))),
+                new Person(new Name("Bruce Wayne"), new Phone("92875639"), new Email("bruce@wayne.com"),
+                        new Education("Stanford"), new Gpa("4"), new Address("1 Wayne Manor, New York NY"),
+                        getTagSet(Arrays.asList("Hardware Testing", "Business Analysis", "Finance", "Cyber Crime"),
+                                Arrays.asList("Project Consultant", "Crime Analyst"), Arrays.asList(
+                                "Thomas Wayne"))),
+                new Person(new Name("Peter Parker"), new Phone("92874339"), new Email("peterp@gmail.com"),
+                        new Education("Brooklyn High School"), new Gpa("4"), new Address("99 Sunflower Dr, Brooklyn " +
+                        "NY"), getTagSet(Arrays.asList( "Electrical Engineering", "Java", "Python",
+                                "Design", "Photography"), Arrays.asList("Advanced Graphics Designer", "Software " +
+                                "Testing"),
+                        Arrays.asList(
+                                "Stan Lee"))),
+                new Person(new Name("Claire Smith"), new Phone("98765432"), new Email("claireS@gmail.com"),
+                        new Education("Oxford"), new Gpa("3"), new Address("12 Biscuits Way, Oxford"),
+                        getTagSet(Arrays.asList("C#", "PHP", "Linux", "C++", "Finance"), Arrays.asList("Systems " +
+                                        "Analyst")
+                                , Arrays.asList("Elon Musk"))),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                     new Education("NUS"), new Gpa("3"), new Address("Blk 45 Aljunied Street 85, #11-31"),
-                    getTagSet(Arrays.asList("Swift", "Java", "Linux"), Arrays.asList("OS Developer")))
+                    getTagSet(Arrays.asList("Swift", "Java", "Linux", "Operating Systems", "Graphic Design",
+                            "Hardware"),
+                            Arrays.asList(
+                            "Project Consultant"),
+                            Arrays.asList(
+                            "Steve Jobs")))
         };
     }
 
@@ -56,13 +103,16 @@ public class SampleDataUtil {
     /**
      * Returns a tag set containing the list of strings given.
      */
-    public static Set<SkillsTag> getTagSet(List<String> skills, List<String> positions) {
+    public static Set<SkillsTag> getTagSet(List<String> skills, List<String> positions, List<String> endorsements) {
         final Set<SkillsTag> tagSet = new HashSet<>();
         for (String skill : skills) {
             tagSet.add(new SkillsTag(skill, "skill"));
         }
         for (String pos : positions) {
             tagSet.add(new SkillsTag(pos, "pos"));
+        }
+        for (String end: endorsements){
+            tagSet.add(new SkillsTag(end, "endorse"));
         }
 
         return tagSet;

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -24,22 +24,24 @@ public class SampleDataUtil {
         return new Person[]{
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                     new Education("NUS"), new Gpa("3"), new Address("Blk 30 Geylang Street 29, #06-40"),
-                    getTagSet(Arrays.asList("PHP", "Java"), Arrays.asList("UIDeveloper", "Graphics"))),
+                    getTagSet(Arrays.asList("PHP", "Java"), Arrays.asList("UI Developer",
+                            "Advanced Graphics Designer"))),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                     new Education("NUS"), new Gpa("3"), new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                    getTagSet(Arrays.asList("HTML", "JavaScript"), Arrays.asList("FrontEnd", "WebDev"))),
+                    getTagSet(Arrays.asList("HTML", "JavaScript", "C++"), Arrays.asList("Front End Specialist",
+                            "Web Developer"))),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                     new Education("NUS"), new Gpa("3"), new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                    getTagSet(Arrays.asList("Cplusplus", "Java"), Arrays.asList("Security"))),
+                    getTagSet(Arrays.asList("C++", "Java"), Arrays.asList("Cyber Crime Analyst"))),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                     new Education("NUS"), new Gpa("3"), new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                    getTagSet(Arrays.asList("Python", "SQL"), Arrays.asList("Databases", "SystemsAnalyst"))),
+                    getTagSet(Arrays.asList("Python", "SQL"), Arrays.asList("Databases", "Systems Analyst"))),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                     new Education("NUS"), new Gpa("3"), new Address("Blk 47 Tampines Street 20, #17-35"),
-                    getTagSet(Arrays.asList("Java", "JavaScript"), Arrays.asList("SoftwareEngineer"))),
+                    getTagSet(Arrays.asList("Java", "JavaScript"), Arrays.asList("Software Engineer"))),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                     new Education("NUS"), new Gpa("3"), new Address("Blk 45 Aljunied Street 85, #11-31"),
-                    getTagSet(Arrays.asList("Swift", "Java", "Linux"), Arrays.asList("OSDeveloper")))
+                    getTagSet(Arrays.asList("Swift", "Java", "Linux"), Arrays.asList("OS Developer")))
         };
     }
 
@@ -57,10 +59,10 @@ public class SampleDataUtil {
     public static Set<SkillsTag> getTagSet(List<String> skills, List<String> positions) {
         final Set<SkillsTag> tagSet = new HashSet<>();
         for (String skill : skills) {
-            tagSet.add(new SkillsTag(skill, "yellow"));
+            tagSet.add(new SkillsTag(skill, "skill"));
         }
         for (String pos : positions) {
-            tagSet.add(new SkillsTag(pos, "pink"));
+            tagSet.add(new SkillsTag(pos, "pos"));
         }
 
         return tagSet;

--- a/src/main/java/seedu/address/storage/JsonAdaptedTag.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTag.java
@@ -12,7 +12,7 @@ import seedu.address.model.tag.SkillsTag;
 class JsonAdaptedTag {
 
     private final String tagName;
-    private final String tagColor;
+    private final String tagType;
 
     /**
      * Constructs a {@code JsonAdaptedTag} with the given {@code tagName}.
@@ -21,7 +21,8 @@ class JsonAdaptedTag {
     @JsonCreator
     public JsonAdaptedTag(String tagName) {
         this.tagName = tagName;
-        this.tagColor = "teal";
+        this.tagType = "pos";
+
     }
 
     /**
@@ -29,7 +30,7 @@ class JsonAdaptedTag {
      */
     public JsonAdaptedTag(SkillsTag source) {
         this.tagName = source.tagName;
-        this.tagColor = source.tagColor;
+        this.tagType = source.tagType;
     }
 
     @JsonValue
@@ -46,7 +47,7 @@ class JsonAdaptedTag {
         if (!SkillsTag.isValidTagName(tagName)) {
             throw new IllegalValueException(SkillsTag.MESSAGE_CONSTRAINTS);
         }
-        return new SkillsTag(tagName, tagColor);
+        return new SkillsTag(tagName, tagType);
     }
 
 }


### PR DESCRIPTION
Refactoring Tag instantiation-using 'type' parameter instead of 'color'
Skill and Position accept more than just alphanumeric characters
Endorse command created with format: "endorse (index) n/(employee name)" 
-employee endorsement appears as a teal tag
-cannot endorse a candidate twice
-editing a person replaces all current tags except endorsements are kept
